### PR TITLE
Commons io

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/download/InputStreamDownload.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/download/InputStreamDownload.java
@@ -23,7 +23,7 @@ import java.io.OutputStream;
 
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.io.IOUtils;
+import com.google.common.io.ByteStreams;
 
 /**
  * Handles download by reading from a input stream byte by byte.
@@ -55,7 +55,7 @@ public class InputStreamDownload implements Download {
 		writeDetails(response);
 
 		OutputStream out = response.getOutputStream();
-		IOUtils.copy(stream, out);
+		ByteStreams.copy(stream, out);
 	}
 
 	void writeDetails(HttpServletResponse response) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultHttpResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultHttpResult.java
@@ -25,7 +25,8 @@ import java.io.Reader;
 
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.io.IOUtils;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.CharStreams;
 
 /**
  * Implementation that delegates to HttpServletResponse
@@ -98,7 +99,7 @@ public class DefaultHttpResult implements HttpResult {
 
 	public HttpResult body(InputStream body) {
 		try {
-			IOUtils.copy(body, response.getOutputStream());
+		    ByteStreams.copy(body, response.getOutputStream());
 		} catch (IOException e) {
 			throw new ResultException("Couldn't write to response body", e);
 		}
@@ -107,7 +108,7 @@ public class DefaultHttpResult implements HttpResult {
 
 	public HttpResult body(Reader body) {
 		try {
-			IOUtils.copy(body, response.getWriter());
+		    CharStreams.copy(body, response.getWriter());
 		} catch (IOException e) {
 			throw new ResultException("Couldn't write to response body", e);
 		}


### PR DESCRIPTION
This commit removes mandatory dependency of commons-io. Since the guava is mandatory too, we have two library that do the same work.

Now only fileupload with commons-fileupload has a dependency of commons-io.
