### PR TITLE
extract ognl creation to a protected method

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/OgnlParametersProvider.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/OgnlParametersProvider.java
@@ -181,7 +181,7 @@ public class OgnlParametersProvider implements ParametersProvider {
 	private OgnlContext createOgnlContextFor(Parameter param, ResourceBundle bundle) {
 		OgnlContext context;
 		try {
-			context = (OgnlContext) Ognl.createDefaultContext(new GenericNullHandler(removal).instantiate(param.actualType()));
+			context = createOgnlContext(new GenericNullHandler(removal).instantiate(param.actualType()));
 		} catch (Exception ex) {
 			throw new InvalidParameterException("unable to instantiate type " + param.type, ex);
 		}
@@ -193,6 +193,10 @@ public class OgnlParametersProvider implements ParametersProvider {
 		Ognl.setTypeConverter(context, adapter);
 
 		return context;
+	}
+
+	protected OgnlContext createOgnlContext(Object root) {
+		return (OgnlContext) Ognl.createDefaultContext(root);
 	}
 
 	private Object createSimpleParameter(Parameter param, String[] values, ResourceBundle bundle) {


### PR DESCRIPTION
it only extracts it to a protected method. It allows programmers to extend that OgnlParametersProviders class and modify the Ognl the way s/he wants.
