### PR TITLE
Ensure priority of Serialization packages

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/DefaultRepresentationResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/DefaultRepresentationResult.java
@@ -18,7 +18,6 @@ package br.com.caelum.vraptor.serialization;
 import static br.com.caelum.vraptor.view.Results.status;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import br.com.caelum.vraptor.Result;
@@ -73,18 +72,5 @@ public class DefaultRepresentationResult implements RepresentationResult {
 		result.use(status()).notAcceptable();
 
 		return new IgnoringSerializer();
-	}
-
-	private final class PackageComparator implements Comparator<Serialization> {
-		private int number(Serialization s) {
-			if (s.getClass().getPackage().getName().startsWith("br.com.caelum.vraptor.serialization")) {
-				return 1;
-			}
-			return 0;
-		}
-
-		public int compare(Serialization o1, Serialization o2) {
-			return number(o1) - number(o2);
-		}
 	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/PackageComparator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/PackageComparator.java
@@ -1,0 +1,38 @@
+package br.com.caelum.vraptor.serialization;
+
+import java.util.Comparator;
+
+final class PackageComparator implements Comparator<Serialization> {
+	private int number(Serialization s) {
+		String packageName = s.getClass().getPackage().getName();
+		if (packageName.startsWith("br.com.caelum.vraptor.serialization")
+		 || packageName.startsWith("br.com.caelum.vraptor.restfulie.serialization")) {
+			return 1;
+		}
+		return 0;
+	}
+	
+	private int giveMorePriorityToRestfulie(Serialization o1, Serialization o2) {
+		String packageNameO1 = o1.getClass().getPackage().getName();
+		String packageNameO2 = o2.getClass().getPackage().getName();
+		
+		if(packageNameO1.startsWith("br.com.caelum.vraptor.serialization") 
+		&& packageNameO2.startsWith("br.com.caelum.vraptor.restfulie.serialization")) {
+			return 1;
+		}
+		
+		return 0;
+	}
+
+	public int compare(Serialization o1, Serialization o2) {
+		int numberO1 = number(o1);
+		int numberO2 = number(o2);
+		int compareResult = numberO1 - numberO2;
+		
+		if(compareResult == 0) {
+			return giveMorePriorityToRestfulie(o1, o2);
+		}
+
+		return compareResult;
+	}
+}

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/serialization/PackageComparatorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/serialization/PackageComparatorTest.java
@@ -1,0 +1,64 @@
+package br.com.caelum.vraptor.serialization;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import pacote.antes.da.caelum.DumbSerialization;
+import br.com.caelum.vraptor.restfulie.serialization.RestfulSerialization;
+import br.com.caelum.vraptor.serialization.xstream.XStreamJSONSerialization;
+import br.com.caelum.vraptor.serialization.xstream.XStreamXMLSerialization;
+
+public class PackageComparatorTest {
+
+	@Test
+	public void shouldSortBasedOnPackageNamesLessPriorityToCaelumInitialList3rdPartyFirst() {
+		List<Serialization> serializers = new ArrayList<Serialization>();
+
+		serializers.add(new DumbSerialization());
+		serializers.add(new XStreamXMLSerialization(null, null, null));
+		serializers.add(new XStreamJSONSerialization(null, null, null));
+		serializers.add(new HTMLSerialization(null, null));
+		serializers.add(new RestfulSerialization(null, null, null, null, null));
+
+		Collections.sort(serializers, new PackageComparator());
+		
+		Assert.assertEquals("pacote.antes.da.caelum", serializers.get(0).getClass().getPackage().getName());
+
+	}
+
+	@Test
+	public void shouldSortBasedOnPackageNamesLessPriorityToCaelumInitialList3rdPartyLast() {
+		List<Serialization> serializers = new ArrayList<Serialization>();
+		
+		serializers.add(new XStreamXMLSerialization(null, null, null));
+		serializers.add(new XStreamJSONSerialization(null, null, null));
+		serializers.add(new HTMLSerialization(null, null));
+		serializers.add(new RestfulSerialization(null, null, null, null, null));
+		serializers.add(new DumbSerialization());
+		
+		Collections.sort(serializers, new PackageComparator());
+		
+		Assert.assertEquals("pacote.antes.da.caelum", serializers.get(0).getClass().getPackage().getName());
+	}
+
+	@Test
+	public void shouldSortBasedOnPackageNamesLessPriorityToCaelumMoreToRestfulieInitialList3rdPartyLast() {
+		List<Serialization> serializers = new ArrayList<Serialization>();
+		
+		serializers.add(new XStreamXMLSerialization(null, null, null));
+		serializers.add(new XStreamJSONSerialization(null, null, null));
+		serializers.add(new HTMLSerialization(null, null));
+		serializers.add(new RestfulSerialization(null, null, null, null, null));
+		serializers.add(new DumbSerialization());
+		
+		Collections.sort(serializers, new PackageComparator());
+		
+		Assert.assertEquals("pacote.antes.da.caelum", serializers.get(0).getClass().getPackage().getName());
+		Assert.assertEquals("br.com.caelum.vraptor.restfulie.serialization", serializers.get(1).getClass().getPackage().getName());
+	}
+}

--- a/vraptor-core/src/test/java/pacote/antes/da/caelum/DumbSerialization.java
+++ b/vraptor-core/src/test/java/pacote/antes/da/caelum/DumbSerialization.java
@@ -1,0 +1,25 @@
+package pacote.antes.da.caelum;
+
+import br.com.caelum.vraptor.serialization.Serialization;
+import br.com.caelum.vraptor.serialization.Serializer;
+
+/**
+ * Test Serialization's comparator
+ *  
+ * @author acdesouza
+ */
+public class DumbSerialization implements Serialization {
+
+	public <T> Serializer from(T object) {
+		return null;
+	}
+
+	public <T> Serializer from(T object, String alias) {
+		return null;
+	}
+
+	public boolean accepts(String format) {
+		return false;
+	}
+
+}


### PR DESCRIPTION
Ensure priority of Serialization packages: first 3rd party, then br.com.caelum.vraptor.restfulie.serialization last br.com.caelum.vraptor.serialization.

As explained: http://groups.google.com/group/caelum-vraptor-dev/browse_thread/thread/a2856c64c311d17a
