### PR TITLE
Set the status code first than serialize.

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultStatus.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultStatus.java
@@ -142,8 +142,8 @@ public class DefaultStatus implements Status {
 	}
 
 	public void badRequest(List<?> errors) {
-		result.use(representation()).from(errors, "errors").serialize();
 		response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+		result.use(representation()).from(errors, "errors").serialize();
 	}
 
 	public void forbidden(String message) {


### PR DESCRIPTION
Status code setted before serialize the response to return the correct status on error.
