### PR TITLE
VRaptor2RequestExecution is not replaceable

### DIFF
--- a/vraptor-core/build.properties
+++ b/vraptor-core/build.properties
@@ -1,4 +1,4 @@
-version = 3.3.2-SNAPSHOT
+version = 3.4.0-SNAPSHOT
 
 libs.dir = lib
 common.dir = ../common

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
@@ -101,7 +101,7 @@ public class VRaptor implements Filter {
 		servletContext = cfg.getServletContext();
 		BasicConfiguration config = new BasicConfiguration(servletContext);
 		init(config.getProvider(), new DefaultStaticContentHandler(servletContext));
-		logger.info("VRaptor 3.3.2-SNAPSHOT successfuly initialized");
+		logger.info("VRaptor 3.4.0-SNAPSHOT successfuly initialized");
 	}
 
 	void init(ContainerProvider provider, StaticContentHandler handler) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/BaseComponents.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/BaseComponents.java
@@ -178,6 +178,7 @@ import br.com.caelum.vraptor.view.RefererResult;
 import br.com.caelum.vraptor.view.SessionFlashScope;
 import br.com.caelum.vraptor.view.Status;
 import br.com.caelum.vraptor.view.ValidationViewsFactory;
+import br.com.caelum.vraptor.vraptor2.VRaptor2RequestExecution;
 
 import com.thoughtworks.xstream.converters.SingleValueConverter;
 
@@ -225,7 +226,8 @@ public class BaseComponents {
     private static final Map<Class<?>, Class<?>> PROTOTYPE_COMPONENTS = classMap(
     		InterceptorStack.class, 						DefaultInterceptorStack.class,
     		RequestExecution.class, 						EnhancedRequestExecution.class,
-    		XStreamBuilder.class, 						    XStreamBuilderImpl.class
+    		XStreamBuilder.class, 							XStreamBuilderImpl.class,
+    		RequestExecution.class,							VRaptor2RequestExecution.class
     );
 
     private static final Map<Class<?>, Class<?>> REQUEST_COMPONENTS = classMap(
@@ -329,15 +331,15 @@ public class BaseComponents {
 			return NullProxyInitializer.class;
 		}
 	}
-    
+
     private static Class<? extends InstanceCreator> getInstanceCreator() {
         if (isClassPresent("org.objenesis.ObjenesisStd")) {
             return ObjenesisInstanceCreator.class;
         }
-        
+
         return ReflectionInstanceCreator.class;
     }
-    
+
     private static Class<? extends Proxifier> getProxifier() {
         if (isClassPresent("net.sf.cglib.proxy.Factory")) {
             return CglibProxifier.class;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/vraptor2/VRaptor2RequestExecution.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/vraptor2/VRaptor2RequestExecution.java
@@ -31,7 +31,6 @@ import br.com.caelum.vraptor.interceptor.ParametersInstantiatorInterceptor;
 import br.com.caelum.vraptor.interceptor.ResourceLookupInterceptor;
 import br.com.caelum.vraptor.interceptor.download.DownloadInterceptor;
 import br.com.caelum.vraptor.interceptor.multipart.MultipartInterceptor;
-import br.com.caelum.vraptor.ioc.Component;
 import br.com.caelum.vraptor.ioc.PrototypeScoped;
 import br.com.caelum.vraptor.vraptor2.outject.OutjectionInterceptor;
 
@@ -40,7 +39,6 @@ import br.com.caelum.vraptor.vraptor2.outject.OutjectionInterceptor;
  *
  * @author Guilherme Silveira
  */
-@Component
 @PrototypeScoped
 public class VRaptor2RequestExecution implements RequestExecution {
 


### PR DESCRIPTION
In our application, we have a custom implementation of RequestExecution. Until last VRaptor version, it worked as expected. With the introduction of VRaptor2RequestExecution, VRaptor doesn't consider our implementation (actually it does sometimes, but it's random).

Making VRaptor2RequestExecution replaceable and updating version to 3.4.0-SNAPSHOT
