### PR TITLE
xstream should be mandatory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,6 @@
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
 			<version>1.3.1</version>
-			<optional>true</optional>
 		</dependency>
 
 


### PR DESCRIPTION
Hi, xstream cannot be opcional anymore, there are some xstream components being used here

https://github.com/caelum/vraptor/blob/master/vraptor-core/src/main/java/br/com/caelum/vraptor/core/BaseComponents.java

Regards
