### PR TITLE
Closing the inputstream in InputStreamDownload

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/download/InputStreamDownload.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/download/InputStreamDownload.java
@@ -58,6 +58,8 @@ public class InputStreamDownload implements Download {
 
 		OutputStream out = response.getOutputStream();
 		ByteStreams.copy(stream, out);
+		
+		stream.close();
 	}
 
 	void writeDetails(HttpServletResponse response) {


### PR DESCRIPTION
Related to the issue #406. Just closing the inputstream after ByteStreams.copy.

It is not necessary to close the outputStream, because the DownloadInterceptor already does the job.
