### PR TITLE
FileNotFound Exception when Running Under Webby

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/scan/ScannotationComponentScanner.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/scan/ScannotationComponentScanner.java
@@ -18,6 +18,7 @@ package br.com.caelum.vraptor.scan;
 import static com.google.common.base.Objects.firstNonNull;
 import static com.google.common.io.Closeables.closeQuietly;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
@@ -74,6 +75,8 @@ public class ScannotationComponentScanner implements ComponentScanner {
             AnnotationDB db = createAnnotationDB();
             db.scanArchives(webInfClasses);
             return db.getAnnotationIndex();
+        } catch (FileNotFoundException e) {
+        	return Collections.emptyMap();
         } catch (IOException e) {
             throw new ScannerException("Could not scan WEB-INF/classes", e);
         }


### PR DESCRIPTION
Webby (https://github.com/sonatype/m2eclipse-webby) is an M2Eclipse Plugin which lets you run (via Cargo) an Embedded Container from Maven War Projects. This way, it lets you do class reloading on the fly, as well as with excellent integration between Maven and Eclipse.

However, Webby simply does not create a WEB-INF/classes directory. Thus, when running vraptor applications, one must be extremely careful. In particular, it throws up a FileNotFoundException.

Actually, the WEB-INF/classes dir seems not to be obligatory per se. Thus, I added a small workaround to simply return an Empty Collection when it fails.

vRaptor Users are advised to make it explicitly which classes it should scan, via `br.com.caelum.vraptor.packages` `context-param` on `web.xml` file. Example:

```
    <context-param>
        <param-name>br.com.caelum.vraptor.packages</param-name>
        <param-value>com.ingenieux.bpnc.web</param-value>
    </context-param>
```
