### PR TITLE
Simple fix for the package prioritization.

### DIFF
--- a/maven_fix.sh
+++ b/maven_fix.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-mvn install:install-file -DgroupId=org.hibernate -DartifactId=hibernate-validator -Dversion=4.0.2.GA -Dclassifier=new -Dpackaging=jar -Dfile=vraptor-core/lib/optional/hibernate/hibernate-validator-4.0.2.GA.jar
-
-
+# Had to change this fix in my branch...
+mvn install:install-file -DgroupId=org.hibernate -DartifactId=hibernate-validator -Dversion=4.0.2.GA -Dclassifier=new -Dpackaging=jar -Dfile=vraptor-core/lib/optional/hibernate/hibernate-validator-4.2.0.Final.jar

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/PackageComparator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/PackageComparator.java
@@ -1,12 +1,12 @@
 /***
  * Copyright (c) 2009 Caelum - www.caelum.com.br/opensource All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -18,7 +18,7 @@ package br.com.caelum.vraptor.serialization;
 import java.util.Comparator;
 
 /**
- * 
+ *
  * @author A.C de Souza
  * @since 3.4.0
  */
@@ -31,16 +31,16 @@ final class PackageComparator implements Comparator<Serialization> {
 		}
 		return 0;
 	}
-	
+
 	private int giveMorePriorityToRestfulie(Serialization o1, Serialization o2) {
 		String packageNameO1 = o1.getClass().getPackage().getName();
 		String packageNameO2 = o2.getClass().getPackage().getName();
-		
-		if(packageNameO1.startsWith("br.com.caelum.vraptor.serialization") 
-		&& packageNameO2.startsWith("br.com.caelum.vraptor.restfulie.serialization")) {
-			return 1;
+
+		if(packageNameO1.startsWith("br.com.caelum.vraptor.restfulie.serialization")
+		&& packageNameO2.startsWith("br.com.caelum.vraptor.serialization")) {
+			return -1;
 		}
-		
+
 		return 0;
 	}
 
@@ -48,7 +48,7 @@ final class PackageComparator implements Comparator<Serialization> {
 		int numberO1 = number(o1);
 		int numberO2 = number(o2);
 		int compareResult = numberO1 - numberO2;
-		
+
 		if(compareResult == 0) {
 			return giveMorePriorityToRestfulie(o1, o2);
 		}


### PR DESCRIPTION
Hi everyone,

When I ran a mvn test in the master branch today I received the following error:

Failed tests:   shouldSortBasedOnPackageNamesLessPriorityToCaelumMoreToRestfulieInitialList3rdPartyLast(br.com.caelum.vraptor.serialization.PackageComparatorTest): expected:<....com.caelum.vraptor.[restfulie.serialization]> but was:<....com.caelum.vraptor.[serialization.xstream]>

I'm not sure if this is still needed but I came up with a very simple fix that made the test pass.

Also, I needed to do a simple hack on the maven_fix.sh to resolve the dependencies.

Cheers.
