### PR TITLE
hibernate-jpa

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.hibernate.javax.persistence</groupId>
+			<artifactId>hibernate-jpa-2.0-api</artifactId>
+			<version>1.0.1.Final</version>
+		</dependency>
+		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-annotations</artifactId>
 			<version>3.3.1.GA</version>


### PR DESCRIPTION
We also need to add hibernate-jpa-2.0 in order to use metamodel.
