### PR TITLE
ensures serializee will be initialized when VRaptorClassMapper is instanciated

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorClassMapper.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorClassMapper.java
@@ -32,7 +32,7 @@ import com.thoughtworks.xstream.mapper.MapperWrapper;
 public class VRaptorClassMapper extends MapperWrapper {
 
 	private final Supplier<TypeNameExtractor> extractor;
-	private Serializee serializee;
+	private Serializee serializee = new Serializee();
 	
 	public VRaptorClassMapper(Mapper wrapped, Supplier<TypeNameExtractor> supplier) {
 		super(wrapped);


### PR DESCRIPTION
more info:
http://www.guj.com.br/java/281356-vraptor--restfulie---serializee-null
(Portuguese)
