### PR TITLE
compatibility with recent versions of guava

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/InterceptorListPriorToExecutionExtractor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/InterceptorListPriorToExecutionExtractor.java
@@ -25,7 +25,7 @@ import br.com.caelum.vraptor.core.InterceptorStack;
 import br.com.caelum.vraptor.ioc.ApplicationScoped;
 import br.com.caelum.vraptor.resource.ResourceMethod;
 
-import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 
 /**
  * Extracts all interceptors which are supposed to be applied for this current
@@ -49,7 +49,7 @@ public class InterceptorListPriorToExecutionExtractor implements Interceptor {
     }
 
     public void intercept(InterceptorStack stack, ResourceMethod method, Object resourceInstance) throws InterceptionException {
-    	for (Class<? extends Interceptor> type : Iterables.reverse(registry.all())) {
+    	for (Class<? extends Interceptor> type : Lists.reverse(registry.all())) {
 			stack.addAsNext(type);
 		}
         stack.next(method, resourceInstance);


### PR DESCRIPTION
Guava's Iterables.reverse(List list) was removed in recent versions,
using Lists.reverse(List list) instead
