### PR TITLE
changing hamcrest dependency from optional to required

### DIFF
--- a/vraptor-core/pom.xml
+++ b/vraptor-core/pom.xml
@@ -224,13 +224,11 @@
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-core</artifactId>
 			<version>1.2</version>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-library</artifactId>
 			<version>1.2</version>
-			<optional>true</optional>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
I updated my project to VRaptor 3.5.1 and when trying to upload to heroku I got:
`[ERROR] class file for org.hamcrest.Matcher not found`

I'm using fluent VRaptor Validation:
`this.that(notEmpty(name), "validation", "validation.required", this.i18n("user.name"));`

I think hamcrest dependencies should be required to avoid this kind of error.
