### PR TITLE
Added redirected() method to Result

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/Result.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/Result.java
@@ -68,6 +68,10 @@ public interface Result {
 	 */
     boolean used();
 
+	/**
+	 * Whether this result was redirected.
+	 */
+    boolean redirected();
     /**
      * Return all included attributes via Result.include();
      * @return

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/AbstractResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/AbstractResult.java
@@ -29,6 +29,8 @@ import br.com.caelum.vraptor.view.Results;
  * @since 3.1.2
  */
 public abstract class AbstractResult implements Result {
+	
+	protected boolean redirected;
 
 	public void forwardTo(String uri) {
 		use(page()).forwardTo(uri);
@@ -36,6 +38,7 @@ public abstract class AbstractResult implements Result {
 
 	public void redirectTo(String uri) {
 		use(page()).redirectTo(uri);
+		this.redirected = true;
 	}
 
 	public <T> T forwardTo(Class<T> controller) {
@@ -43,6 +46,7 @@ public abstract class AbstractResult implements Result {
 	}
 
 	public <T> T redirectTo(Class<T> controller) {
+		this.redirected = true;
 		return use(logic()).redirectTo(controller);
 	}
 
@@ -52,6 +56,7 @@ public abstract class AbstractResult implements Result {
 
 	@SuppressWarnings("unchecked")
 	public <T> T redirectTo(T controller) {
+		this.redirected = true;
 		return (T) redirectTo(controller.getClass());
 	}
 
@@ -74,16 +79,22 @@ public abstract class AbstractResult implements Result {
 	}
 
 	public void permanentlyRedirectTo(String uri) {
+		this.redirected = true;
 		use(status()).movedPermanentlyTo(uri);
 	}
 
 	public <T> T permanentlyRedirectTo(Class<T> controller) {
+		this.redirected = true;
 		return use(status()).movedPermanentlyTo(controller);
 	}
 
 	@SuppressWarnings("unchecked")
 	public <T> T permanentlyRedirectTo(T controller) {
+		this.redirected = true;
 		return (T) use(status()).movedPermanentlyTo(controller.getClass());
 	}
 
+	public boolean redirected() {
+		return this.redirected;
+	}
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/core/DefaultResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/core/DefaultResultTest.java
@@ -231,4 +231,45 @@ public class DefaultResultTest {
     	result.include(null);
     	verify(request, never()).setAttribute(anyString(), anyObject());
     }
+   
+    @Test
+    public void shouldReturnTrueWhenCallRedirectedAfterRedirectingToStringURI() throws Exception {
+    	shouldDelegateToPageResultOnRedirectToURI();
+    	assertThat(result.redirected(), is(true));
+    }
+    
+    @Test
+    public void shouldReturnTrueWhenCallRedirectedAfterRedirectionToController() throws Exception {
+    	shouldDelegateToLogicResultOnRedirectToLogic();
+    	assertThat(result.redirected(), is(true));
+    }  
+    
+    @Test
+    public void shouldReturnTrueWhenCallRedirectedAfterRedirectionToControllerInstance() throws Exception {
+    	shouldDelegateToLogicResultOnRedirectToLogicWithInstance();
+    	assertThat(result.redirected(), is(true));
+    }
+    
+    @Test
+    public void shouldReturnTrueWhenCallRedirectedAfterPermanentlyRedirectingToStringURI() throws Exception {
+    	shouldDelegateToStatusOnPermanentlyRedirectToUri();
+    	assertThat(result.redirected(), is(true));
+    }
+    
+    @Test
+    public void shouldReturnTrueWhenCallRedirectedAfterPermanentlyRedirectionToController() throws Exception {
+    	shouldDelegateToStatusOnPermanentlyRedirectToControllerClass();
+    	assertThat(result.redirected(), is(true));
+    }  
+    
+    @Test
+    public void shouldReturnTrueWhenCallRedirectedAfterPermanentlyRedirectionToControllerInstance() throws Exception {
+    	shouldDelegateToStatusOnPermanentlyRedirectToControllerInstance();
+    	assertThat(result.redirected(), is(true));
+    }
+    
+    @Test
+    public void shouldReturnFalseWhenCallRedirectedWithoutMakingAnyRedirection() throws Exception {
+    	assertThat(result.redirected(), is(false));
+    }
 }


### PR DESCRIPTION
Similar to used(), it tells whether the result has been redirected or not. With that, the user should be able to verify redirections via interceptors, for example.
