### PR TITLE
ordering Deserializers to override vraptor with 3rd party deserializers

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/deserialization/DefaultDeserializers.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/deserialization/DefaultDeserializers.java
@@ -15,8 +15,12 @@
  */
 package br.com.caelum.vraptor.deserialization;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import br.com.caelum.vraptor.core.BaseComponents;
 import br.com.caelum.vraptor.ioc.ApplicationScoped;
@@ -36,9 +40,19 @@ public class DefaultDeserializers implements Deserializers {
 	private final Map<String, Class<? extends Deserializer>> deserializers = new HashMap<String, Class<? extends Deserializer>>();
 
 	public DefaultDeserializers() {
-		for (Class<? extends Deserializer> type : BaseComponents.getDeserializers()) {
+		for (Class<? extends Deserializer> type : sortDeserializations(BaseComponents.getDeserializers())) {
 			register(type);
 		}
+	}
+	
+	/**
+	 * Override this method if you want another ordering strategy to deserializers .
+	 */
+	protected List<Class<? extends Deserializer>> sortDeserializations(Set<Class<? extends Deserializer>> deserializersSet) {
+		ArrayList<Class<? extends Deserializer>> deserializers = new ArrayList<Class<? extends Deserializer>>(deserializersSet);
+		Collections.sort(deserializers, new PackageComparator());
+		
+		return deserializers;
 	}
 	
 	public Deserializer deserializerFor(String contentType, Container container) {

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/deserialization/PackageComparator.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/deserialization/PackageComparator.java
@@ -1,0 +1,19 @@
+package br.com.caelum.vraptor.deserialization;
+
+import java.util.Comparator;
+
+public class PackageComparator implements Comparator<Class<? extends Deserializer>> {
+
+	public int compare(Class<? extends Deserializer> o1, Class<? extends Deserializer> o2) {
+		String o1PackageName = o1.getPackage().getName();
+		String o2PackageName = o2.getPackage().getName();
+		if (o1PackageName.startsWith("br.com.caelum.vraptor.deserialization") && !o2PackageName.startsWith("br.com.caelum.vraptor.deserialization")) {
+			return -1;
+		} else if (!o1PackageName.startsWith("br.com.caelum.vraptor.deserialization") && o2PackageName.startsWith("br.com.caelum.vraptor.deserialization")) {
+			return 1;
+		} else {
+			return 0;
+		}
+	}
+
+}

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/deserialization/PackageComparatorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/deserialization/PackageComparatorTest.java
@@ -1,0 +1,44 @@
+package br.com.caelum.vraptor.deserialization;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import br.com.caelum.vraptor.deserialization.gson.GsonDeserialization;
+import br.com.caelum.vraptor.other.pack4ge.DumbDeserialization;
+
+public class PackageComparatorTest {
+	
+	@Test
+	public void shouldSortBasedOnPackageNamesMorePriorityToCaelumInitialList3rdPartyFirst() {
+		List<Class<? extends Deserializer>> deserializers = new ArrayList<Class<? extends Deserializer>>();
+		
+		deserializers.add(DumbDeserialization.class);
+		deserializers.add(GsonDeserialization.class);
+		deserializers.add(JsonDeserializer.class);
+		
+		Collections.sort(deserializers, new PackageComparator());
+		
+		assertTrue(deserializers.get(0).getPackage().getName().startsWith("br.com.caelum.vraptor.deserialization"));
+		assertTrue(deserializers.get(2).getPackage().getName().equals("br.com.caelum.vraptor.other.pack4ge"));
+	}
+	
+	@Test
+	public void shouldSortBasedOnPackageNamesMorePriorityToCaelumInitialList3rdPartyLast() {
+		List<Class<? extends Deserializer>> deserializers = new ArrayList<Class<? extends Deserializer>>();
+		
+		deserializers.add(GsonDeserialization.class);
+		deserializers.add(JsonDeserializer.class);
+		deserializers.add(DumbDeserialization.class);
+		
+		Collections.sort(deserializers, new PackageComparator());
+		
+		assertTrue(deserializers.get(0).getPackage().getName().startsWith("br.com.caelum.vraptor.deserialization"));
+		assertTrue(deserializers.get(2).getPackage().getName().equals("br.com.caelum.vraptor.other.pack4ge"));
+	}
+	
+}

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/other/pack4ge/DumbDeserialization.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/other/pack4ge/DumbDeserialization.java
@@ -1,0 +1,19 @@
+package br.com.caelum.vraptor.other.pack4ge;
+
+import java.io.InputStream;
+
+import br.com.caelum.vraptor.deserialization.Deserializer;
+import br.com.caelum.vraptor.resource.ResourceMethod;
+
+/**
+ * Test Deserialization's comparator
+ * @author Nykolas Lima
+ *
+ */
+public class DumbDeserialization implements Deserializer {
+
+	public Object[] deserialize(InputStream inputStream, ResourceMethod method) {
+		return null;
+	}
+
+}


### PR DESCRIPTION
If we want to override GsonDeserialization or any other deserializer, when VRaptor registers the deserializers, it overrides 3rd party deserializers by VRaptor's deserilizers.

Now we are ordering deserializers to give to VRaptor's deserializers more priority on List, when we register it, the 3rd party deserializers overrides VRaptor's deserializers.
