### PR TITLE
Test for error in DefaultRouter. Method inheritance with args.

### DIFF
--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/DefaultRouterTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/DefaultRouterTest.java
@@ -287,6 +287,9 @@ public class DefaultRouterTest {
 		
 		public void withParameter(Dog dog) {
 		}
+		
+		public void withParameter(Dog dog, String a) {
+		}
 	}
 
 	@br.com.caelum.vraptor.Resource
@@ -326,6 +329,15 @@ public class DefaultRouterTest {
 		registerRulesFor(InheritanceExample.class);
 		final Method method = MyResource.class.getMethod("withParameter", Dog.class);
 		String url = router.urlFor(InheritanceExample.class, method, new Object[] {});
+		assertThat(router.parse(url, HttpMethod.POST, null).getMethod(), is(equalTo(method)));
+	}
+	
+	@Test
+	public void shouldReturnRouterIfMethodWithParameterOver() throws NoSuchMethodException, SecurityException {
+		registerRulesFor(MyResource.class);
+		registerRulesFor(InheritanceExample.class);
+		final Method method = MyResource.class.getMethod("withParameter", Dog.class, String.class);
+		String url = router.urlFor(MyResource.class, method, new Object[] {});
 		assertThat(router.parse(url, HttpMethod.POST, null).getMethod(), is(equalTo(method)));
 	}
 


### PR DESCRIPTION
The problem is in the class: 
https://github.com/caelum/vraptor/blob/master/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultParametersControl.java?source=cc#L89

I use the linkTo in post methods with parameters with empty values, because I just need route for post, and args will be created by forms.

So, paramNames.length != paramValues.length should be paramNames.length < paramValues.length to be correct.
What do you think?
Can I fix it, is it that way?
