### PR TITLE
Upgrading commons-fileupload to version 1.3

### DIFF
--- a/vraptor-core/pom.xml
+++ b/vraptor-core/pom.xml
@@ -210,7 +210,7 @@
 		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
-			<version>1.2.1</version>
+			<version>1.3</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/multipart/CommonsUploadMultipartInterceptorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/multipart/CommonsUploadMultipartInterceptorTest.java
@@ -1,6 +1,5 @@
 package br.com.caelum.vraptor.interceptor.multipart;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.io.ByteStreams.toByteArray;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -37,7 +36,6 @@ import br.com.caelum.vraptor.http.InvalidParameterException;
 import br.com.caelum.vraptor.http.MutableRequest;
 import br.com.caelum.vraptor.resource.ResourceMethod;
 import br.com.caelum.vraptor.validator.I18nMessage;
-import br.com.caelum.vraptor.validator.Validations;
 
 /**
  * Test class for uploading features using commons-fileupload.
@@ -177,7 +175,11 @@ public class CommonsUploadMultipartInterceptorTest {
         
         when(request.getContentType()).thenReturn("multipart/form-data");
         when(request.getMethod()).thenReturn("POST");
-        when(mockUpload.parseRequest(request)).thenReturn(newArrayList(item));
+        
+        List<FileItem> items = new ArrayList<FileItem>();
+        items.add(item);
+        
+        when(mockUpload.parseRequest(request)).thenReturn(items);
         
         interceptor.intercept(stack, method, instance);
     }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/multipart/MockFileItem.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/multipart/MockFileItem.java
@@ -9,6 +9,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 
 import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload.FileItemHeaders;
 
 public class MockFileItem
     implements FileItem {
@@ -105,5 +106,12 @@ public class MockFileItem
         throws Exception {
 
     }
-
+    
+    public FileItemHeaders getHeaders() {
+        return null;
+    }
+    
+    public void setHeaders(FileItemHeaders arg0) {
+        
+    }
 }


### PR DESCRIPTION
This PR upgrades commons-fileupload to version 1.3, that supports generics, reducing warnings. This version is full compatible with previous version. Changelog here: https://commons.apache.org/proper/commons-fileupload/changes-report.html#a1.3
