### PR TITLE
Update Gson api to 2.2.4

### DIFF
--- a/vraptor-core/pom.xml
+++ b/vraptor-core/pom.xml
@@ -169,7 +169,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.2.1</version>
+			<version>2.2.4</version>
 		</dependency>
 		<!-- [/deserialization] -->
 


### PR DESCRIPTION
Update Gson api to 2.2.4

This release fixes for possible DoS attack due to poor String hashing. 
Apparently this version is full compatible with previous version.
More details:
https://sites.google.com/site/gson/gson-roadmap
