### PR TITLE
removing VRaptor's version from log

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
@@ -111,7 +111,7 @@ public class VRaptor implements Filter {
 		servletContext = cfg.getServletContext();
 		BasicConfiguration config = new BasicConfiguration(servletContext);
 		init(config.getProvider());
-		logger.info("VRaptor 3.5.2-SNAPSHOT successfuly initialized");
+		logger.info("VRaptor successfuly initialized");
 	}
 
 	void init(ContainerProvider provider) {


### PR DESCRIPTION
Every new version we need to update this log.

VRaptor's version 3.5.2 is logging wrong: "VRaptor 3.5.2-SNAPSHOT successfuly initialized"

Removing version from this log will avoid wrong logs if we forget to update this. (I believe it's really easy to forget to update it)
