### PR TITLE
Now we get category name only when needs

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/MethodValidatorFactoryCreator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/MethodValidatorFactoryCreator.java
@@ -61,7 +61,6 @@ public class MethodValidatorFactoryCreator
     @PostConstruct
     public void buildFactory() {
         instance = Validation.byDefaultProvider().configure()
-                .parameterNameProvider(new CustomParameterNameProvider(nameProvider))
                 .constraintValidatorFactory(constraintValidatorFactory).buildValidatorFactory();
 
         logger.debug("Initializing Bean Validation (1.1 supported)");
@@ -78,43 +77,4 @@ public class MethodValidatorFactoryCreator
         }
         return instance;
     }
-
-    /**
-     * Allow vraptor to use paranamer to discovery method parameter names.
-     *
-     * @author Otávio Scherer Garcia
-     * @since 3.5.2
-     */
-    class CustomParameterNameProvider
-        implements javax.validation.ParameterNameProvider {
-
-        private final ParameterNameProvider nameProvider;
-
-        public CustomParameterNameProvider(ParameterNameProvider nameProvider) {
-            this.nameProvider = nameProvider;
-        }
-
-        /**
-         * Returns an empty list of parameter names, since we don't validate constructors.
-         */
-        public List<String> getParameterNames(Constructor<?> constructor) {
-            return emptyParameters(constructor.getParameterTypes().length);
-        }
-
-        /**
-         * Returns the parameter names for the method, skiping if method is inherited from object.
-         */
-        public List<String> getParameterNames(Method method) {
-            if (OBJECT_METHODS.contains(method)) {
-                return emptyParameters(method.getParameterTypes().length);
-            }
-
-            return asList(nameProvider.parameterNamesFor(method));
-        }
-
-        private List<String> emptyParameters(int length) {
-            return asList(new String[length]);
-        }
-    }
-
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/MethodValidatorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/MethodValidatorTest.java
@@ -94,19 +94,19 @@ public class MethodValidatorTest {
     
     @Test
     public void shouldAcceptIfMethodHasConstraint() {
-        interceptor = new MethodValidatorInterceptor(null, null, null, null, factory.getValidator());
+        interceptor = new MethodValidatorInterceptor(null, null, null, null, factory.getValidator(), null);
     	assertThat(interceptor.accepts(withConstraint), is(true));
     	
-        interceptor = new MethodValidatorInterceptor(null, null, null, null, factory.getValidator());
+        interceptor = new MethodValidatorInterceptor(null, null, null, null, factory.getValidator(), null);
     	assertThat(interceptor.accepts(withTwoConstraints), is(true));
     	
-        interceptor = new MethodValidatorInterceptor(null, null, null, null, factory.getValidator());
+        interceptor = new MethodValidatorInterceptor(null, null, null, null, factory.getValidator(), null);
     	assertThat(interceptor.accepts(cascadeConstraint), is(true));
     }
 
     @Test
     public void shouldNotAcceptIfMethodHasConstraint() {
-        interceptor = new MethodValidatorInterceptor(null, null, null, null, factory.getValidator());
+        interceptor = new MethodValidatorInterceptor(null, null, null, null, factory.getValidator(), null);
     	assertThat(interceptor.accepts(withoutConstraint), is(false));
     }
 
@@ -117,7 +117,7 @@ public class MethodValidatorTest {
         info.setParameters(new Object[] { null });
         info.setResourceMethod(withConstraint);
 
-        interceptor = new MethodValidatorInterceptor(l10n, interpolator, validator, info, factory.getValidator());
+        interceptor = new MethodValidatorInterceptor(l10n, interpolator, validator, info, factory.getValidator(), provider);
         when(l10n.getLocale()).thenReturn(new Locale("pt", "br"));
 
         MyController controller = new MyController();
@@ -134,7 +134,7 @@ public class MethodValidatorTest {
         info.setParameters(new Object[] { null });
         info.setResourceMethod(withConstraint);
 
-        interceptor = new MethodValidatorInterceptor(l10n, interpolator, validator, info, factory.getValidator());
+        interceptor = new MethodValidatorInterceptor(l10n, interpolator, validator, info, factory.getValidator(), provider);
 
         MyController controller = new MyController();
         interceptor.intercept(stack, info.getResourceMethod(), controller);
@@ -151,7 +151,7 @@ public class MethodValidatorTest {
         info.setParameters(new Object[] { null, new Customer(null, null) });
         info.setResourceMethod(withTwoConstraints);
 
-        interceptor = new MethodValidatorInterceptor(l10n, interpolator, validator, info, factory.getValidator());
+        interceptor = new MethodValidatorInterceptor(l10n, interpolator, validator, info, factory.getValidator(), provider);
         when(l10n.getLocale()).thenReturn(new Locale("pt", "br"));
 
         MyController controller = new MyController();


### PR DESCRIPTION
Solves the issue described here: https://groups.google.com/forum/#!topic/caelum-vraptor/H4xXdW81RX0

This code already exists in vraptor4. Instead of allow bean validation to get category name using paranamer in bootstrap, we only get a category name when an error occurs.
