### PR TITLE
Adds check existence of http request attribute, to parameters injection

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/RequestAttributeInstantiator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/RequestAttributeInstantiator.java
@@ -17,6 +17,8 @@
 
 package br.com.caelum.vraptor.http.iogi;
 
+import java.util.Enumeration;
+
 import javax.servlet.http.HttpServletRequest;
 
 import br.com.caelum.iogi.Instantiator;
@@ -35,6 +37,29 @@ final class RequestAttributeInstantiator implements Instantiator<Object> {
 
 	public boolean isAbleToInstantiate(Target<?> target) {
 		Object value = request.getAttribute(target.getName());
-		return value != null && target.getClassType().isInstance(value);
+		return (value != null && isSameType(target, value)) || (value == null && existsAttribute(target.getName()));
+	}
+	
+	private boolean isSameType(Target<?> target, Object value) {
+		return target.getClassType().isInstance(value);
+	}
+	
+	private boolean existsAttribute(String name) {
+		
+		Enumeration<String> attributes = request.getAttributeNames();
+		
+		boolean exists = false;
+		
+		while (attributes.hasMoreElements()) {
+			
+			String attributeName = attributes.nextElement();
+			
+			if (attributeName.equals(name)) {
+				exists = true;
+				break;
+			}
+		}
+		
+		return exists;
 	}
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/http/ParametersProviderTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/http/ParametersProviderTest.java
@@ -87,7 +87,8 @@ public abstract class ParametersProviderTest {
 	when(converters.to(String.class)).thenReturn(new StringConverter());
 
 	when(nameProvider.parameterNamesFor(any(AccessibleObject.class))).thenReturn(new String[0]);
-
+	when(request.getAttributeNames()).thenReturn(Collections.enumeration(Collections.<String> emptyList()));
+	
 	buyA 		= method("buyA", House.class);
 	kick 		= method("kick", AngryCat.class);
 	error 		= method("error", WrongCat.class);

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/http/iogi/RequestAttributeInstantiatorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/http/iogi/RequestAttributeInstantiatorTest.java
@@ -1,0 +1,64 @@
+package br.com.caelum.vraptor.http.iogi;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.enumeration;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import br.com.caelum.iogi.reflection.Target;
+
+public class RequestAttributeInstantiatorTest {
+
+	private static final String TARGET_ATTRIBUTE_NAME = "attributeName";
+
+	private HttpServletRequest mockRequest;
+	
+	private RequestAttributeInstantiator requestAttributeInstantiator;
+	
+	@Before
+	public void setup() {
+		
+		mockRequest = mock(HttpServletRequest.class);
+		
+		requestAttributeInstantiator = new RequestAttributeInstantiator(mockRequest);
+		
+		when(mockRequest.getAttribute(TARGET_ATTRIBUTE_NAME)).thenReturn("attribute value");
+		
+		when(mockRequest.getAttributeNames()).thenReturn(enumeration(asList(TARGET_ATTRIBUTE_NAME)));
+		
+	}
+	
+	@Test
+	public void shouldAbleToInstantiateWhenRequestAttributeExistsAndSameTypeOfTarget() {
+		
+		Target<String> target = Target.create(String.class, TARGET_ATTRIBUTE_NAME);
+		
+		assertTrue(requestAttributeInstantiator.isAbleToInstantiate(target));
+	}
+	
+	@Test
+	public void shouldNotAbleToInstantiateWhenRequestAttributeExistsButDifferentTypeOfTarget() {
+		
+		Target<Integer> target = Target.create(Integer.class, TARGET_ATTRIBUTE_NAME);
+		
+		assertFalse(requestAttributeInstantiator.isAbleToInstantiate(target));
+	}
+	
+	@Test
+	public void shouldAbleToInstantiateWhenRequestAttributeExistsButValueIsNull() {
+		
+		Target<String> target = Target.create(String.class, TARGET_ATTRIBUTE_NAME);
+		
+		when(mockRequest.getAttribute(TARGET_ATTRIBUTE_NAME)).thenReturn(null);
+		
+		assertTrue(requestAttributeInstantiator.isAbleToInstantiate(target));
+	}
+		
+}


### PR DESCRIPTION
Amigos,

O que motivou essa alteração foi o uso em conjunto com a anotação @Load, disponível no plugin https://github.com/caelum/vraptor-jpa.

Se a pesquisa por id, realizada por esse plugin, não encontrar nenhum registro, será criado um atributo na requisição com valor null. Dessa forma, ao tentar injetar os parâmetros, o VRaptor irá tentar criar uma instância desse objeto (como faria normalmente). Mas nesse caso, o comportamento esperado seria a injeção do valor null, pois é como esse atributo existe no request.

Obrigado.
