### PR TITLE
Updated slf4j-api & slf4j-log4j12 to 1.6.6

### DIFF
--- a/vraptor-core/pom.xml
+++ b/vraptor-core/pom.xml
@@ -31,12 +31,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.6.1</version>
+			<version>1.6.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.1</version>
+			<version>1.6.6</version>
 		</dependency>
 		<dependency>
 			<groupId>net.vidageek</groupId>


### PR DESCRIPTION
Tomcat7 is logging to catalina.out messages like the following:

```
SEVERE: A web application created a ThreadLocal with key of type
[org.apache.log4j.helpers.ThreadLocalMap] (value
[org.apache.log4j.helpers.ThreadLocalMap@3ac5b23e]) and a value of type
[java.util.Hashtable] (value [{}]) but failed to remove it when the web
application was stopped. To prevent a memory leak, the ThreadLocal has
been forcibly removed.
```

This is caused by log4j 1.2.16. The proposed fix is to utilize log4j 1.2.17, which fixes this particular
Memoryleak (described in
http://logging.apache.org/log4j/1.2/changes-report.html#a1.2.17 and
https://issues.apache.org/bugzilla/show_bug.cgi?id=50486)
