### PR TITLE
NullPointerException using ognl Evaluation when the request parameter is null in some template frameworks.

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
@@ -52,7 +52,7 @@ import br.com.caelum.vraptor.ioc.ContainerProvider;
  * @author Fabio Kung
  */
 public class VRaptor implements Filter {
-	private static final String VERSION = "3.5.4-SNAPSHOT";
+	private static final String VERSION = "3.5.5-SNAPSHOT";
 	
 	private ContainerProvider provider;
 	private ServletContext servletContext;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
@@ -52,7 +52,7 @@ import br.com.caelum.vraptor.ioc.ContainerProvider;
  * @author Fabio Kung
  */
 public class VRaptor implements Filter {
-	private static final String VERSION = "3.5.5-SNAPSHOT";
+	private static final String VERSION = "3.5.4-SNAPSHOT";
 	
 	private ContainerProvider provider;
 	private ServletContext servletContext;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/ReflectionBasedNullHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/ReflectionBasedNullHandler.java
@@ -59,6 +59,10 @@ public class ReflectionBasedNullHandler extends ObjectNullHandler {
 		return list.instantiate(target, property, (Type) context.get("rootType"));
 	}
 
+	if(ctx.getCurrentEvaluation() == null){
+		return null;
+	}
+	
 	int indexInParent = ctx.getCurrentEvaluation().getNode().getIndexInParent();
 	int maxIndex = ctx.getRootEvaluation().getNode().jjtGetNumChildren() - 1;
 


### PR DESCRIPTION
Class: ReflectionBasedNullHandler
Framework involved: Thymeleaf

When using a attribute with a null value from request parameter in Thymeleaf, for some motive, it's not possible to find the Evaluation object from the context object, leading to a NullpointerException in the ReflectionBasedNullHandler class. But if the attribute is not null, the method executes normally.

ReflectionBasedNullHandler int indexInParent = ctx.getCurrentEvaluation().getNode().getIndexInParent();
ctx.getCurrentEvaluation() <- returns null

HTML  input type="text" th:value="${#strings.toString(param.metadado)}" 
param.metadado is null, so nothing should be shown on screen, instead, it makes "ctx.getCurrentEvaluation()" returns null leading to a NullPointerException

I've made a fork/commit showing how the problem was solved here at the project being constructed with VRaptor3 + Thymeleaf:

44547c529cd91186e5e208320698e1129102ef77

Best regards, 
Marcelo Portilho.