### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/BaseComponents.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/BaseComponents.java
@@ -199,7 +199,7 @@ import com.thoughtworks.xstream.converters.SingleValueConverter;
  *
  * @author guilherme silveira
  */
-public class BaseComponents {
+public final class BaseComponents {
 
 	static final Logger logger = LoggerFactory.getLogger(BaseComponents.class);
 
@@ -324,6 +324,10 @@ public class BaseComponents {
 		Deserializes.class,
 		Intercepts.class
 	};
+
+	private BaseComponents() {
+		throw new InstantiationError( "Must not instantiate this class" );		
+	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	private static final Set<Class<? extends Deserializer>> DESERIALIZERS = new HashSet(Arrays.asList(

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/spring/VRaptorRequestHolder.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/spring/VRaptorRequestHolder.java
@@ -21,8 +21,12 @@ import br.com.caelum.vraptor.core.RequestInfo;
 /**
  * @author Fabio Kung
  */
-public class VRaptorRequestHolder {
+public final class VRaptorRequestHolder {
 	private static final ThreadLocal<RequestInfo> vraptorRequests = new ThreadLocal<RequestInfo>();
+
+	private VRaptorRequestHolder() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
 	public static RequestInfo currentRequest() {
 	return vraptorRequests.get();

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/util/StringUtils.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/util/StringUtils.java
@@ -25,7 +25,11 @@ import java.util.List;
 
  * @author Lucas Cavalcanti
  */
-public class StringUtils {
+public final class StringUtils {
+
+	private StringUtils() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
 	public static String decapitalize(String name) {
 	if (name.length() == 1) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/util/Stringnifier.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/util/Stringnifier.java
@@ -21,7 +21,11 @@ import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 
-public class Stringnifier {
+public final class Stringnifier {
+
+	private Stringnifier() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
 	static String argumentsToString(Class<?>[] parameterTypes) {
 		StringBuilder builder = new StringBuilder();

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/util/collections/Functions.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/util/collections/Functions.java
@@ -20,7 +20,11 @@ import br.com.caelum.vraptor.ioc.Container;
 
 import com.google.common.base.Function;
 
-public class Functions {
+public final class Functions {
+
+	private Functions() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
 	public static <T> Function<Class<? extends T>, ? extends T> instanceWith(final Container container) {
 		return new Function<Class<? extends T>, T>() {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/Results.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/Results.java
@@ -28,7 +28,11 @@ import br.com.caelum.vraptor.serialization.XMLSerialization;
  *
  * @author Guilherme Silveira
  */
-public class Results {
+public final class Results {
+
+	private Results() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
 	/**
 	 * Offers server side forward and include for web pages.<br>

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/VRaptorMatchers.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/VRaptorMatchers.java
@@ -26,7 +26,12 @@ import org.hamcrest.TypeSafeMatcher;
 
 import br.com.caelum.vraptor.http.route.Route;
 
-public class VRaptorMatchers {
+public final class VRaptorMatchers {
+
+	private VRaptorMatchers () {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
+
 	public static Matcher<Collection<?>> hasOneCopyOf(final Object item) {
 		return new TypeSafeMatcher<Collection<?>>(){
 

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/http/ognl/AbstractOgnlTestSupport.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/http/ognl/AbstractOgnlTestSupport.java
@@ -11,6 +11,10 @@ import br.com.caelum.vraptor.proxy.ReflectionInstanceCreator;
 
 public final class AbstractOgnlTestSupport {
 
+	private AbstractOgnlTestSupport () {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
+
 	public static void configOgnl(Converters converters) throws OgnlException {
 		Proxifier proxifier = new JavassistProxifier(new ReflectionInstanceCreator());
 		OgnlRuntime.setNullHandler(Object.class, new ReflectionBasedNullHandler(proxifier));

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/VRaptorMatchers.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/VRaptorMatchers.java
@@ -33,7 +33,11 @@ import br.com.caelum.vraptor.validator.ValidationMessage;
  * 
  * @author Guilherme Silveira
  */
-public class VRaptorMatchers {
+public final class VRaptorMatchers {
+
+	private VRaptorMatchers () {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
 	public static TypeSafeMatcher<ResourceMethod> resourceMethod(final Method method) {
 	return new TypeSafeMatcher<ResourceMethod>() {

--- a/vraptor-mydvds/src/main/java/br/com/caelum/vraptor/mydvds/validation/CustomMatchers.java
+++ b/vraptor-mydvds/src/main/java/br/com/caelum/vraptor/mydvds/validation/CustomMatchers.java
@@ -24,7 +24,7 @@ import org.hamcrest.TypeSafeMatcher;
  * @author Lucas Cavalcanti
  *
  */
-public class CustomMatchers {
+public final class CustomMatchers {
 
     private static TypeSafeMatcher<String> EMPTY = new TypeSafeMatcher<String>() {
 
@@ -43,6 +43,10 @@ public class CustomMatchers {
         }
 
     };
+
+	private CustomMatchers() {
+		throw new InstantiationError( "Must not instantiate this class" );
+	}
 
     /**
      * matches if the given string is not empty. This matcher is null-safe.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
Please let me know if you have any questions.
M-Ezzat