### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expression…

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/l10n/LocaleBasedBigDecimalConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/l10n/LocaleBasedBigDecimalConverter.java
@@ -57,7 +57,7 @@ public class LocaleBasedBigDecimalConverter
 		
 		try {
 			final Locale locale = localization.getLocale();
-			DecimalFormat fmt = ((DecimalFormat) DecimalFormat.getInstance(locale));
+			DecimalFormat fmt = (DecimalFormat) DecimalFormat.getInstance(locale);
 			fmt.setParseBigDecimal(true);
 			
 			return (BigDecimal) fmt.parse(value);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/l10n/LocaleBasedDoubleConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/l10n/LocaleBasedDoubleConverter.java
@@ -57,7 +57,7 @@ public class LocaleBasedDoubleConverter
 	
 		try {
 			final Locale locale = localization.getLocale();
-			DecimalFormat fmt = ((DecimalFormat) DecimalFormat.getInstance(locale));
+			DecimalFormat fmt = (DecimalFormat) DecimalFormat.getInstance(locale);
 	
 			return fmt.parse(value).doubleValue();
 		} catch (ParseException e) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/l10n/LocaleBasedFloatConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/l10n/LocaleBasedFloatConverter.java
@@ -57,7 +57,7 @@ public class LocaleBasedFloatConverter
 	
 		try {
 			final Locale locale = localization.getLocale();
-			DecimalFormat fmt = ((DecimalFormat) DecimalFormat.getInstance(locale));
+			DecimalFormat fmt = (DecimalFormat) DecimalFormat.getInstance(locale);
 	
 			return fmt.parse(value).floatValue();
 		} catch (ParseException e) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/l10n/LocaleBasedPrimitiveDoubleConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/l10n/LocaleBasedPrimitiveDoubleConverter.java
@@ -57,7 +57,7 @@ public class LocaleBasedPrimitiveDoubleConverter implements Converter<Double> {
 
 		try {
 			final Locale locale = localization.getLocale();
-			DecimalFormat fmt = ((DecimalFormat) DecimalFormat.getInstance(locale));
+			DecimalFormat fmt = (DecimalFormat) DecimalFormat.getInstance(locale);
 
 			return fmt.parse(value).doubleValue();
 		} catch (ParseException e) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/l10n/LocaleBasedPrimitiveFloatConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/l10n/LocaleBasedPrimitiveFloatConverter.java
@@ -58,7 +58,7 @@ public class LocaleBasedPrimitiveFloatConverter
 	
 		try {
 			final Locale locale = localization.getLocale();
-			DecimalFormat fmt = ((DecimalFormat) DecimalFormat.getInstance(locale));
+			DecimalFormat fmt = (DecimalFormat) DecimalFormat.getInstance(locale);
 	
 			return fmt.parse(value).floatValue();
 		} catch (ParseException e) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/DefaultTypeNameExtractor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/DefaultTypeNameExtractor.java
@@ -45,7 +45,7 @@ public class DefaultTypeNameExtractor implements TypeNameExtractor {
 		}
 
 		if (generic instanceof TypeVariable<?>) {
-			return nameFor(((TypeVariable<?>) generic));
+			return nameFor((TypeVariable<?>) generic);
 		}
 
 		return nameFor((Class<?>) generic);
@@ -66,7 +66,7 @@ public class DefaultTypeNameExtractor implements TypeNameExtractor {
 	}
 
 	private String nameFor(WildcardType wild) {
-		if ((wild.getLowerBounds().length != 0)) {
+		if (wild.getLowerBounds().length != 0) {
 			return nameFor(wild.getLowerBounds()[0]);
 		} else {
 			return nameFor(wild.getUpperBounds()[0]);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/guice/GuiceComponentRegistry.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/guice/GuiceComponentRegistry.java
@@ -140,7 +140,7 @@ public class GuiceComponentRegistry implements ComponentRegistry {
 		Constructor constructor = getConstructor(componentType);
 		for (Type type : constructor.getGenericParameterTypes()) {
 			if (type instanceof ParameterizedType) {
-				ParameterizedType ptype =((ParameterizedType) type);
+				ParameterizedType ptype =(ParameterizedType) type;
 				if (ptype.getRawType() instanceof Class<?> && List.class.isAssignableFrom((Class<?>) ptype.getRawType())
 						&& ptype.getRawType() instanceof Class<?> && !listTypes.contains(ptype.getActualTypeArguments()[0])) {
 					listTypes.add((Class<?>) ptype.getActualTypeArguments()[0]);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/Exclusions.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/Exclusions.java
@@ -48,8 +48,8 @@ public class Exclusions implements ExclusionStrategy {
 	}
 
 	private boolean isCompatiblePath(Entry<String, Class<?>> path, Class<?> definedIn, String fieldName) {
-		return (path.getValue().equals(definedIn) && (path.getKey().equals(fieldName) || path.getKey().endsWith(
-				"." + fieldName)));
+		return path.getValue().equals(definedIn) && (path.getKey().equals(fieldName) || path.getKey().endsWith(
+				"." + fieldName));
 	}
 
 	public boolean shouldSkipClass(Class<?> clazz) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorClassMapper.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorClassMapper.java
@@ -70,7 +70,7 @@ public class VRaptorClassMapper extends MapperWrapper {
 	}
 
 	private boolean isCompatiblePath(Entry<String, Class<?>> path, Class definedIn, String fieldName) {
-		return (path.getValue().equals(definedIn) && (path.getKey().equals(fieldName) || path.getKey().endsWith("." + fieldName)));
+		return path.getValue().equals(definedIn) && (path.getKey().equals(fieldName) || path.getKey().endsWith("." + fieldName));
 	}
 
 	@Override

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamBuilderImpl.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamBuilderImpl.java
@@ -86,8 +86,8 @@ public class XStreamBuilderImpl implements XStreamBuilder {
 	  * @return configured hierarchical driver
 	  */
 	protected HierarchicalStreamDriver getHierarchicalStreamDriver() {
-	final String newLine = (indented ? INDENTED_NEW_LINE : DEFAULT_NEW_LINE);
-	final char[] lineIndenter = (indented ? INDENTED_LINE_INDENTER : DEFAULT_LINE_INDENTER);
+	final String newLine = indented ? INDENTED_NEW_LINE : DEFAULT_NEW_LINE;
+	final char[] lineIndenter = indented ? INDENTED_LINE_INDENTER : DEFAULT_LINE_INDENTER;
 
 	return new JsonHierarchicalStreamDriver() {
 		public HierarchicalStreamWriter createWriter(Writer writer) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/util/ISO8601Util.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/util/ISO8601Util.java
@@ -73,9 +73,9 @@ public final class ISO8601Util {
 			int month	= matcher.group(2) != null ? Integer.valueOf(matcher.group(2)) - 1 : 0;
 			int day		= matcher.group(3) != null ? Integer.valueOf(matcher.group(3)) : 0;
 			
-			int h	= (matcher.group(4) != null ? Integer.valueOf(matcher.group(4)) : 0);
-			int m	= (matcher.group(5) != null ? Integer.valueOf(matcher.group(5)) : 0);
-			int s	= (matcher.group(6) != null ? Integer.valueOf(matcher.group(6)) : 0);
+			int h	= matcher.group(4) != null ? Integer.valueOf(matcher.group(4)) : 0;
+			int m	= matcher.group(5) != null ? Integer.valueOf(matcher.group(5)) : 0;
+			int s	= matcher.group(6) != null ? Integer.valueOf(matcher.group(6)) : 0;
 			int ms	= Math.round(Float.parseFloat("0." + (matcher.group(7) != null ? matcher.group(7) : "0")) * 1000);
 
 			TimeZone timeZone = TimeZone.getTimeZone("GMT" + (matcher.group(8) != null ? matcher.group(8) : ""));

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/ioc/ComponentFactoryIntrospectorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/ioc/ComponentFactoryIntrospectorTest.java
@@ -59,13 +59,13 @@ public class ComponentFactoryIntrospectorTest {
 
 	@Test
 	public void shoudWorkWithSubclassesOfComponenetFactoryImplementations() {
-		Class<?> c = new ComponentFactoryIntrospector().targetTypeForComponentFactory((ClassThatImplementsCFExtending.class));
+		Class<?> c = new ComponentFactoryIntrospector().targetTypeForComponentFactory(ClassThatImplementsCFExtending.class);
 		assertEquals(String.class, c);
 	}
 
 	@Test
 	public void shoudWorkWithImplementationsOfComponenetFactorySubinterfacesImplementations() {
-		Class<?> c = new ComponentFactoryIntrospector().targetTypeForComponentFactory((ClassThatImplementsCFIndirectly.class));
+		Class<?> c = new ComponentFactoryIntrospector().targetTypeForComponentFactory(ClassThatImplementsCFIndirectly.class);
 		assertEquals(String.class, c);
 	}
 
@@ -86,6 +86,6 @@ public class ComponentFactoryIntrospectorTest {
 
 	@Test(expected = ComponentRegistrationException.class)
 	public void shoudNotWorkWithClassesThatDoesNotImplementComponentFactory() {
-		new ComponentFactoryIntrospector().targetTypeForComponentFactory((ClassThatIsNotCFAtAll.class));
+		new ComponentFactoryIntrospector().targetTypeForComponentFactory(ClassThatIsNotCFAtAll.class);
 	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

M-Ezzat