### PR TITLE
squid:MissingDeprecatedCheck - Deprecated elements should have both t…

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/InterceptorStack.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/InterceptorStack.java
@@ -39,6 +39,7 @@ public interface InterceptorStack {
 	void add(Class<? extends Interceptor> interceptor);
 
 	/**
+	 * @deprecated
 	 * Adds this interceptor at the head of the stack.
 	 */
 	@Deprecated

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/HibernateProxyInitializer.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/HibernateProxyInitializer.java
@@ -29,6 +29,7 @@ import br.com.caelum.vraptor.ioc.ApplicationScoped;
  * @deprecated 3.5.0, since persistence plugins have their own projects
  */
 @ApplicationScoped
+@Deprecated
 public class HibernateProxyInitializer implements ProxyInitializer {
 
 	public boolean isProxy(Class<?> clazz) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/PageResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/PageResult.java
@@ -59,18 +59,21 @@ public interface PageResult extends View {
 	 * @deprecated  As of 3.2, replaced by
 	 *		  {@link #redirectTo(String url)}
 	 */
+	@Deprecated
 	void redirect(String url);
 	
 	/**
 	 * @deprecated  As of 3.2, replaced by
 	 *		  {@link #forwardTo(String url)}
 	 */
+	@Deprecated
 	void forward(String url);
 	
 	/**
 	 * @deprecated  As of 3.2, replaced by
 	 *		  {@link #forwardTo()}
 	 */
+	@Deprecated
 	void forward();
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:MissingDeprecatedCheck

Please let me know if you have any questions.

M-Ezzat