### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/Path.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/Path.java
@@ -34,6 +34,12 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Path {
 
+	public static final int LOWEST = Integer.MAX_VALUE;
+	public static final int LOW = Integer.MAX_VALUE/4*3;
+	public static final int DEFAULT = Integer.MAX_VALUE/2;
+	public static final int HIGH = Integer.MAX_VALUE/4;
+	public static final int HIGHEST = 0;
+
 	/**
 	 * All paths that will be mapped to an annotated Resource method. The path value also can be 
 	 * configured in class level and using {@link Get}, {@link Post}, {@link Trace} and {@link Delete} 
@@ -56,11 +62,5 @@ public @interface Path {
 	 *
 	 */
 	int priority() default DEFAULT;
-
-	public static final int LOWEST = Integer.MAX_VALUE;
-	public static final int LOW = Integer.MAX_VALUE/4*3;
-	public static final int DEFAULT = Integer.MAX_VALUE/2;
-	public static final int HIGH = Integer.MAX_VALUE/4;
-	public static final int HIGHEST = 0;
-
+	
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultRoutes.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultRoutes.java
@@ -38,12 +38,12 @@ public class DefaultRoutes implements Routes{
 	private final Proxifier proxifier;
 	private final Router router;
 
+	private String uri;
+
 	public DefaultRoutes(Router router, Proxifier proxifier) {
 		this.router = router;
 		this.proxifier = proxifier;
 	}
-
-	private String uri;
 
 	public <T> T uriFor(final Class<T> type) {
 		return proxifier.proxify(type, new MethodInvocation<T>() {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/RouteNotFoundException.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/RouteNotFoundException.java
@@ -26,10 +26,10 @@ import br.com.caelum.vraptor.VRaptorException;
  */
 public class RouteNotFoundException extends VRaptorException {
 
+	private static final long serialVersionUID = 606801838930057251L;
+
 	public RouteNotFoundException(String msg) {
 		super(msg);
 	}
-
-	private static final long serialVersionUID = 606801838930057251L;
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/scan/WebAppBootstrap.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/scan/WebAppBootstrap.java
@@ -26,13 +26,14 @@ import br.com.caelum.vraptor.ComponentRegistry;
 public interface WebAppBootstrap {
 
 	/**
+	 * Class name of the generated WebAppBootStrap impl
+	 */
+	String STATIC_BOOTSTRAP_NAME = "br.com.caelum.vraptor.generated.StaticProjectBootstrap";
+
+	/**
 	 * Configure all components using ComponentRegistry
 	 * @param registry
 	 */
 	void configure (ComponentRegistry registry);
 
-	/**
-	 * Class name of the generated WebAppBootStrap impl
-	 */
-	String STATIC_BOOTSTRAP_NAME = "br.com.caelum.vraptor.generated.StaticProjectBootstrap";
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamBuilderImpl.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamBuilderImpl.java
@@ -48,7 +48,13 @@ public class XStreamBuilderImpl implements XStreamBuilder {
 	private boolean indented;
 	private boolean withoutRoot;
 	private boolean recursive;
-	
+
+	protected static final String DEFAULT_NEW_LINE = "";
+	protected static final char[] DEFAULT_LINE_INDENTER = {};
+
+	protected static final String INDENTED_NEW_LINE = "\n";
+	protected static final char[] INDENTED_LINE_INDENTER = { ' ', ' '};
+
 	public XStreamBuilderImpl(XStreamConverters converters, TypeNameExtractor extractor) {
 		this.converters = converters;
 		this.extractor = extractor;
@@ -65,12 +71,6 @@ public class XStreamBuilderImpl implements XStreamBuilder {
 		xstream.getVRaptorMapper().getSerializee().setRecursive(recursive);
 		return configure(xstream);
 	}
-	
-	protected static final String DEFAULT_NEW_LINE = "";
-	protected static final char[] DEFAULT_LINE_INDENTER = {};
-	
-	protected static final String INDENTED_NEW_LINE = "\n";
-	protected static final char[] INDENTED_LINE_INDENTER = { ' ', ' '};
 	
 	public XStream jsonInstance() {
 		return configure(new VRaptorXStream(extractor, getHierarchicalStreamDriver()));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat