### PR TITLE
squid:S2325 - "private" methods that don't access instance data shoul…

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/BooleanConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/BooleanConverter.java
@@ -59,7 +59,7 @@ public class BooleanConverter implements Converter<Boolean> {
 		throw new ConversionError(MessageFormat.format(bundle.getString("is_not_a_valid_boolean"), value));
 	}
 
-	private boolean matches(Set<String> words, String value) {
+	private static boolean matches(Set<String> words, String value) {
 		return words.contains(value);
 	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/LocaleBasedTimeConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/LocaleBasedTimeConverter.java
@@ -50,7 +50,7 @@ public class LocaleBasedTimeConverter implements Converter<Time> {
 		}
 	}
 
-	private boolean isUncompleteTime(String value) {
+	private static boolean isUncompleteTime(String value) {
 		return Pattern.compile("[0-9]{2}\\:[0-9]{2}").matcher(value).find();
 	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultExceptionMapper.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultExceptionMapper.java
@@ -80,7 +80,7 @@ public class DefaultExceptionMapper
 		return hasExceptionCause(e) ? findByException((Exception) e.getCause()) : null;
 	}
 
-	private boolean hasExceptionCause(Exception e) {
+	private static boolean hasExceptionCause(Exception e) {
 		return e.getCause() != null && e.getCause() instanceof Exception;
 	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultStaticContentHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultStaticContentHandler.java
@@ -60,11 +60,11 @@ public class DefaultStaticContentHandler implements StaticContentHandler {
 		return removeQueryStringAndJSessionId(uri);
 	}
 	
-	private String removeQueryStringAndJSessionId(String uri) {
+	private static String removeQueryStringAndJSessionId(String uri) {
 		return uri.replaceAll("[\\?;].+", "");
 	}
 
-	private boolean isAFile(URL resourceUrl) {
+	private static boolean isAFile(URL resourceUrl) {
 		return !resourceUrl.toString().endsWith("/");
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/deserialization/DefaultDeserializers.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/deserialization/DefaultDeserializers.java
@@ -70,7 +70,7 @@ public class DefaultDeserializers implements Deserializers {
 		return null;
 	}
 
-	private String removeChar(String type, String by) {
+	private static String removeChar(String type, String by) {
 		return type.substring(type.lastIndexOf(by)+1);
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/deserialization/JsonDeserializer.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/deserialization/JsonDeserializer.java
@@ -76,7 +76,7 @@ public class JsonDeserializer implements Deserializer{
 		return builder.configure(xStream);
 	}
 
-	private void chooseParam(Class<?>[] types, Object[] params, Object deserialized) {
+	private static void chooseParam(Class<?>[] types, Object[] params, Object deserialized) {
 		for (int i = 0; i < types.length; i++) {
 			if (types[i].isInstance(deserialized)) {
 				params[i] = deserialized;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/deserialization/XStreamXMLDeserializer.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/deserialization/XStreamXMLDeserializer.java
@@ -71,7 +71,7 @@ public class XStreamXMLDeserializer implements XMLDeserializer {
 		return xStream;
 	}
 
-	private void chooseParam(Class<?>[] types, Object[] params, Object deserialized) {
+	private static void chooseParam(Class<?>[] types, Object[] params, Object deserialized) {
 		for (int i = 0; i < types.length; i++) {
 			if (types[i].isInstance(deserialized)) {
 				params[i] = deserialized;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/deserialization/gson/GsonDeserialization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/deserialization/gson/GsonDeserialization.java
@@ -140,7 +140,7 @@ public class GsonDeserialization implements Deserializer {
 		return method.getMethod().getParameterTypes();
 	}
 
-	private Class<?>[] parseGenericParameters(Method method, Class<?> genericType) {
+	private static Class<?>[] parseGenericParameters(Method method, Class<?> genericType) {
 		Class<?>[] paramClasses = method.getParameterTypes();
 		Type[] paramTypes = method.getGenericParameterTypes();
 
@@ -159,7 +159,7 @@ public class GsonDeserialization implements Deserializer {
 		return result;
 	}
 
-	private Class<?> getSuperClassTypeArgument(ResourceMethod method) {
+	private static Class<?> getSuperClassTypeArgument(ResourceMethod method) {
 		Type genericType = method.getResource().getType().getGenericSuperclass();
 
 		if (genericType instanceof ParameterizedType) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/DefaultParameterNameProvider.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/DefaultParameterNameProvider.java
@@ -41,7 +41,7 @@ public class DefaultParameterNameProvider implements ParameterNameProvider{
 	}
 
 	@SuppressWarnings({ "rawtypes" })
-	private Type[] parameterTypes(AccessibleObject methodOrConstructor) {
+	private static Type[] parameterTypes(AccessibleObject methodOrConstructor) {
 		if (methodOrConstructor instanceof Method) {
 			return ((Method)methodOrConstructor).getGenericParameterTypes();
 		} else if (methodOrConstructor instanceof Constructor<?>) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/IogiParametersProvider.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/IogiParametersProvider.java
@@ -98,7 +98,7 @@ public class IogiParametersProvider implements ParametersProvider {
 		return targets;
 	}
 
-	private int methodArity(Method method) {
+	private static int methodArity(Method method) {
 		return method.getGenericParameterTypes().length;
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/ArrayAccessor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/ArrayAccessor.java
@@ -73,7 +73,7 @@ public class ArrayAccessor extends ArrayPropertyAccessor {
 	super.setProperty(context, array, key, value);
 	}
 
-	private Object copyOf(Object array, int desiredLength, int currentLength) {
+	private static Object copyOf(Object array, int desiredLength, int currentLength) {
 	Object newArray = Array.newInstance(array.getClass().getComponentType(), desiredLength + 1);
 	for (int i = 0; i < currentLength; i++) {
 		Array.set(newArray, i, Array.get(array, i));

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/ListAccessor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/ListAccessor.java
@@ -96,7 +96,7 @@ public class ListAccessor extends ListPropertyAccessor {
 		super.setProperty(context, target, key, value);
 	}
 
-	private Class getActualType(Type genericType) {
+	private static Class getActualType(Type genericType) {
 		Class type;
 		if (genericType instanceof ParameterizedType) {
 			type = (Class) ((ParameterizedType) genericType).getActualTypeArguments()[0];

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/ReflectionBasedNullHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/ReflectionBasedNullHandler.java
@@ -95,7 +95,7 @@ public class ReflectionBasedNullHandler extends ObjectNullHandler {
 	return instance;
 	}
 
-	private Object instantiateArray(Class<?> baseType) {
+	private static Object instantiateArray(Class<?> baseType) {
 	return Array.newInstance(baseType.getComponentType(), 0);
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/VRaptorConvertersAdapter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/VRaptorConvertersAdapter.java
@@ -88,7 +88,7 @@ public class VRaptorConvertersAdapter implements TypeConverter {
 	return target.getClass().getComponentType();
 	}
 
-	private Type extractFieldType(Member member) {
+	private static Type extractFieldType(Member member) {
 	return ((Field) member).getGenericType();
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultParametersControl.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultParametersControl.java
@@ -111,7 +111,7 @@ public class DefaultParametersControl implements ParametersControl {
 		return base.replaceAll("\\.\\*", "");
 	}
 
-	private Object selectParam(String key, String[] paramNames, Object[] paramValues) {
+	private static Object selectParam(String key, String[] paramNames, Object[] paramValues) {
 		for (int i = 0; i < paramNames.length; i++) {
 			if (key.matches("^" + paramNames[i] + "(\\..*|$)")) {
 				return paramValues[i];

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouteBuilder.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouteBuilder.java
@@ -198,7 +198,7 @@ public class DefaultRouteBuilder implements RouteBuilder {
 		}
 	}
 
-	private String[] sanitize(String[] parameters) {
+	private static String[] sanitize(String[] parameters) {
 		String[] sanitized = new String[parameters.length];
 		for (int i = 0; i < parameters.length; i++) {
 			sanitized[i] = parameters[i].replaceAll("(\\:.*|\\*)$", "");

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouter.java
@@ -95,7 +95,7 @@ public class DefaultRouter implements Router {
 		return route.resourceMethod(request, uri);
 	}
 
-	private void checkIfThereIsAnotherRoute(String uri, HttpMethod method, Iterator<Route> iterator, Route route) {
+	private static void checkIfThereIsAnotherRoute(String uri, HttpMethod method, Iterator<Route> iterator, Route route) {
 		if (iterator.hasNext()) {
 			Route otherRoute = iterator.next();
 			if (route.getPriority() == otherRoute.getPriority()) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultTypeFinder.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultTypeFinder.java
@@ -59,7 +59,7 @@ public class DefaultTypeFinder implements TypeFinder {
 		}
 		return result;
 	}
-	private String upperFirst(String item) {
+	private static String upperFirst(String item) {
 		return item.substring(0, 1).toUpperCase() + item.substring(1);
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/PathAnnotationRoutesParser.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/PathAnnotationRoutesParser.java
@@ -190,7 +190,7 @@ public class PathAnnotationRoutesParser implements RoutesParser {
 		}
 	}
 
-	private String fixLeadingSlash(String uri) {
+	private static String fixLeadingSlash(String uri) {
 		if (!uri.startsWith("/")) {
 			return  "/" + uri;
 		}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/DefaultTypeNameExtractor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/DefaultTypeNameExtractor.java
@@ -51,7 +51,7 @@ public class DefaultTypeNameExtractor implements TypeNameExtractor {
 		return nameFor((Class<?>) generic);
 	}
 
-	private String nameFor(Class<?> raw) {
+	private static String nameFor(Class<?> raw) {
 		if (raw.isArray()) {
 			return nameFor(raw.getComponentType()) + "List";
 		}
@@ -61,7 +61,7 @@ public class DefaultTypeNameExtractor implements TypeNameExtractor {
 		return StringUtils.lowercaseFirst(name);
 	}
 
-	private String nameFor(TypeVariable<?> variable) {
+	private static String nameFor(TypeVariable<?> variable) {
 		return StringUtils.lowercaseFirst(variable.getName());
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/DeserializingInterceptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/DeserializingInterceptor.java
@@ -111,7 +111,7 @@ public class DeserializingInterceptor implements Interceptor {
 
 	}
 
-	private String mime(String contentType) {
+	private static String mime(String contentType) {
 		if (contentType.contains(";")) {
 			return contentType.split(";")[0];
 		}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/pico/PicoProvider.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/pico/PicoProvider.java
@@ -155,7 +155,7 @@ public class PicoProvider implements ContainerProvider {
 		}
 	}
 
-	private void registerAll(ComponentRegistry registry, Map<Class<?>, Class<?>> scope) {
+	private static void registerAll(ComponentRegistry registry, Map<Class<?>, Class<?>> scope) {
 		for (Map.Entry<Class<?>, Class<?>> entry : scope.entrySet()) {
 		registry.register(entry.getKey(), entry.getValue());
 		registry.register(entry.getValue(), entry.getValue());

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/spring/InjectionBeanPostProcessor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/spring/InjectionBeanPostProcessor.java
@@ -44,7 +44,7 @@ class InjectionBeanPostProcessor extends AutowiredAnnotationBeanPostProcessor {
 	}
 
 	@SuppressWarnings({ "rawtypes" })
-	private Constructor checkIfThereIsOnlyOneNonDefaultConstructor(Class beanClass) {
+	private static Constructor checkIfThereIsOnlyOneNonDefaultConstructor(Class beanClass) {
 	Constructor[] constructors = beanClass.getDeclaredConstructors();
 	if (constructors.length == 1) {
 		if (constructors[0].getParameterTypes().length > 0) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/proxy/ReflectionInstanceCreator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/proxy/ReflectionInstanceCreator.java
@@ -53,7 +53,7 @@ public class ReflectionInstanceCreator
 	}
 	}
 
-	private <T> T useDefaultConstructor(Class<T> clazz) {
+	private static <T> T useDefaultConstructor(Class<T> clazz) {
 	try {
 		return clazz.newInstance();
 	} catch (Exception e) {
@@ -96,7 +96,7 @@ public class ReflectionInstanceCreator
 	 * @param parameterTypes of the constructor to be called, in order.
 	 * @return parameter instances for the given types.
 	 */
-	private Object[] proxyParameters(Class<?>[] parameterTypes) {
+	private static Object[] proxyParameters(Class<?>[] parameterTypes) {
 	return new Object[parameterTypes.length];
 	}
 
@@ -104,7 +104,7 @@ public class ReflectionInstanceCreator
 	 * @param constructors from the type to be proxified
 	 * @return null when there isn't a default (null) constructor
 	 */
-	private Constructor<?> findDefaultConstructor(Constructor<?>[] constructors) {
+	private static Constructor<?> findDefaultConstructor(Constructor<?>[] constructors) {
 	for (Constructor<?> constructor : constructors) {
 		if (constructor.getParameterTypes().length == 0) {
 		return constructor;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/restfulie/controller/ResourceControllerInterceptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/restfulie/controller/ResourceControllerInterceptor.java
@@ -118,7 +118,7 @@ public class ResourceControllerInterceptor<T extends HypermediaResource> impleme
 		return false;
 	}
 
-	private String lowerFirstChar(String simpleName) {
+	private static String lowerFirstChar(String simpleName) {
 		if(simpleName.length()==1) {
 			return simpleName.toLowerCase();
 		}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/restfulie/serialization/LinkConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/restfulie/serialization/LinkConverter.java
@@ -71,7 +71,7 @@ public class LinkConverter implements Converter {
 		}
 	}
 
-	private Object getRoot(Object root) {
+	private static Object getRoot(Object root) {
 		if (root instanceof ConfigurableHypermediaResource) {
 			return ((ConfigurableHypermediaResource) root).getModel();
 		}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/restfulie/serialization/MethodValueSupportConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/restfulie/serialization/MethodValueSupportConverter.java
@@ -61,7 +61,7 @@ public class MethodValueSupportConverter implements Converter {
 		writer.endNode();
 	}
 
-	private String nameFor(Method m) {
+	private static String nameFor(Method m) {
 		String name = m.getName();
 		if (name.startsWith("is")) {
 			return StringUtils.lowercaseFirst(name.substring(2));

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/scan/JavassistBootstrapGenerator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/scan/JavassistBootstrapGenerator.java
@@ -89,7 +89,7 @@ public class JavassistBootstrapGenerator implements BootstrapGenerator {
 		}
 	}
 
-	private String createMethodDef(Collection<String> components) {
+	private static String createMethodDef(Collection<String> components) {
 		StringBuilder methodDef = new StringBuilder()
 			.append("public void configure (br.com.caelum.vraptor.ComponentRegistry registry){");
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/scan/ScannotationComponentScanner.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/scan/ScannotationComponentScanner.java
@@ -107,7 +107,7 @@ public class ScannotationComponentScanner implements ComponentScanner {
 	} while (urls.hasMoreElements());
 	}
 
-	private String toFileName(String resource, URL url) {
+	private static String toFileName(String resource, URL url) {
 	String file = url.getFile().substring(0, url.getFile().length() - resource.length() - 1).replaceAll("(!)(/)?$", "");
 
 	if (!file.startsWith("file:")) {
@@ -138,7 +138,7 @@ public class ScannotationComponentScanner implements ComponentScanner {
 	}
 	}
 
-	private boolean packagesContains(List<String> basePackages, String clazz) {
+	private static boolean packagesContains(List<String> basePackages, String clazz) {
 	for (String basePackage : basePackages) {
 		if (clazz.startsWith(basePackage)) {
 		return true;
@@ -153,7 +153,7 @@ public class ScannotationComponentScanner implements ComponentScanner {
 	results.addAll(myStereotypes);
 	}
 
-	private void addVRaptorStereotypes(HashSet<String> results) {
+	private static void addVRaptorStereotypes(HashSet<String> results) {
 	for (Class<? extends Annotation> stereotype : BaseComponents.getStereotypes()) {
 		results.add(stereotype.getName());
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/OldAndProbablyBuggyConfigurer.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/OldAndProbablyBuggyConfigurer.java
@@ -65,7 +65,7 @@ public class OldAndProbablyBuggyConfigurer {
 		excludesMap.remove(parentType, fieldName);
 	}
 	
-	private String getNameFor(String name) {
+	private static String getNameFor(String name) {
 		String[] path = name.split("\\.");
 		return path[path.length-1];
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorClassMapper.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorClassMapper.java
@@ -69,7 +69,7 @@ public class VRaptorClassMapper extends MapperWrapper {
 		return should;
 	}
 
-	private boolean isCompatiblePath(Entry<String, Class<?>> path, Class definedIn, String fieldName) {
+	private static boolean isCompatiblePath(Entry<String, Class<?>> path, Class definedIn, String fieldName) {
 		return path.getValue().equals(definedIn) && (path.getKey().equals(fieldName) || path.getKey().endsWith("." + fieldName));
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/DefaultBeanValidator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/DefaultBeanValidator.java
@@ -126,7 +126,7 @@ public class DefaultBeanValidator
 		return localization.getLocale() == null ? Locale.getDefault() : localization.getLocale();
 	}
 
-	private boolean hasProperties(String... properties) {
+	private static boolean hasProperties(String... properties) {
 		return properties != null && properties.length > 0;
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultAcceptHeaderToFormat.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultAcceptHeaderToFormat.java
@@ -144,7 +144,7 @@ public class DefaultAcceptHeaderToFormat implements AcceptHeaderToFormat {
 		return new MimeType(string, 1);
 	}
 
-	private double extractQualifier(String string) {
+	private static double extractQualifier(String string) {
 		double qualifier = DEFAULT_QUALIFIER_VALUE;
 		if (string.contains("q=")) {
 			Matcher matcher = Pattern.compile("\\s*q=(.+)\\s*").matcher(string);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPathResolver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPathResolver.java
@@ -67,7 +67,7 @@ public class DefaultPathResolver implements PathResolver {
 	return baseName;
 	}
 
-	private String lowerFirstCharacter(String baseName) {
+	private static String lowerFirstCharacter(String baseName) {
 	return baseName.toLowerCase().substring(0, 1) + baseName.substring(1, baseName.length());
 	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/SessionFlashScope.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/SessionFlashScope.java
@@ -44,7 +44,7 @@ public class SessionFlashScope implements FlashScope {
 		return args;
 	}
 
-	private String nameFor(ResourceMethod method) {
+	private static String nameFor(ResourceMethod method) {
 		return KEY_START + method.getMethod();
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat