### PR TITLE
squid:S106 - Standard outputs should not be used directly to log anyt…

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/scan/VRaptorStaticScanning.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/scan/VRaptorStaticScanning.java
@@ -15,6 +15,9 @@
  */
 package br.com.caelum.vraptor.scan;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collection;
 
 /**
@@ -24,6 +27,7 @@ import java.util.Collection;
  * @since 3.2
  */
 public class VRaptorStaticScanning {
+	private static final Logger LOGGER = LoggerFactory.getLogger(VRaptorStaticScanning.class);
 
 	/**
 	 * @param args[0] (optional) The WEB-INF/web.xml location
@@ -43,14 +47,14 @@ public class VRaptorStaticScanning {
 			cpr = new StandaloneClasspathResolver(webxml);
 		}
 
-		System.out.print("Initiating the scanning...");
+		LOGGER.debug("Initiating the scanning...");
 		ComponentScanner scanner = new ScannotationComponentScanner();
 		Collection<String> classes = scanner.scan(cpr);
-		System.out.println(" done.");
+		LOGGER.debug(" done.");
 
-		System.out.print("Generating the static registry...");
+		LOGGER.debug("Generating the static registry...");
 		BootstrapGenerator generator = new JavassistBootstrapGenerator();
 		generator.generate(classes, cpr);
-		System.out.println(" done.");
+		LOGGER.debug(" done.");
 	}
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/ioc/spring/components/RequestScopedComponent.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/ioc/spring/components/RequestScopedComponent.java
@@ -17,13 +17,17 @@
 package br.com.caelum.vraptor.ioc.spring.components;
 
 import br.com.caelum.vraptor.ioc.RequestScoped;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Fabio Kung
  */
 @RequestScoped
 public class RequestScopedComponent implements RequestScopedContract {
+	private static final Logger LOGGER = LoggerFactory.getLogger(RequestScopedComponent.class);
+
 	public void operation() {
-	System.out.println("operation done");
+		LOGGER.debug("operation done");
 	}
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/GenericController.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/GenericController.java
@@ -1,20 +1,25 @@
 package br.com.caelum.vraptor.view;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Controller used to test Generic Controllers on LinkToHandler
  * @author Nykolas Lima
  *
  */
 public class GenericController<T> {
+	private static final Logger LOGGER = LoggerFactory.getLogger(GenericController.class);
+	
 	public void method(T entity) {
-		System.out.println("Do Something");
+		LOGGER.debug("Do Something");
 	}
 	
 	public void anotherMethod(T entity, String param) {
-		System.out.println("Do Another Thing");
+		LOGGER.debug("Do Another Thing");
 	}
 	
 	public void methodWithoutGenericType(String param) {
-		System.out.println("Without generic");
+		LOGGER.debug("Without generic");
 	}
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/SubGenericController.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/SubGenericController.java
@@ -1,20 +1,25 @@
 package br.com.caelum.vraptor.view;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Controller used to test Generic Controllers on LinkToHandler
  * @author Nykolas Lima
  *
  */
 public class SubGenericController extends GenericController<String> {
+	private static final Logger LOGGER = LoggerFactory.getLogger(SubGenericController.class);
+
 	public void method(String string) {
-		System.out.println("Do something thing by Sub Generic Controller");
+		LOGGER.debug("Do something thing by Sub Generic Controller");
 	}
 	
 	public void okMethod(String string) {
-		System.out.println("OKOK");
+		LOGGER.debug("OKOK");
 	}
 	
 	public void anotherMethod(String string, String param) {
-		System.out.println("Do another thing by Sub Generic Controller");
+		LOGGER.debug("Do another thing by Sub Generic Controller");
 	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S106 - Standard outputs should not be used directly to log anything

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S106

Please let me know if you have any questions.

M-Ezzat