### PR TITLE
squid:UnusedPrivateMethod, squid:S2864 - Unused private method should…

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/BaseComponents.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/BaseComponents.java
@@ -420,19 +420,6 @@ public class BaseComponents {
 		}
 	}
 
-	private static boolean registerIfClassPresent(Map<Class<?>, Class<?>> components, String className, Class<?>... types) {
-		try {
-			Class.forName(className);
-			for (Class<?> type : types) {
-				components.put(type, type);
-			}
-			return true;
-		} catch (ClassNotFoundException e) {
-			/* ok, don't register */
-			return false;
-		}
-	}
-
 	private static void registerIfClassPresent(Set<Class<? extends Converter<?>>> components, String className, Class<? extends Converter<?>>... types) {
 		if (components.contains(types[0])) {
 			return;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/EmptyElementsRemoval.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ognl/EmptyElementsRemoval.java
@@ -80,11 +80,11 @@ public class EmptyElementsRemoval {
 			}
 		}
 		collections.clear();
-		for (SetValue setter : arrays.keySet()) {
-			Object array = arrays.get(setter);
+		for (Map.Entry<SetValue, Object> setValueObjectEntry : arrays.entrySet()) {
+			Object array = setValueObjectEntry.getValue();
 			Object newArray = removeNullsFromArray(array);
 			try {
-				setter.set(newArray);
+				setValueObjectEntry.getKey().set(newArray);
 			} catch (InvocationTargetException e) {
 				throw new VRaptorException(e.getCause());
 			} catch (Exception e) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouter.java
@@ -176,12 +176,4 @@ public class DefaultRouter implements Router {
 			}
 		};
 	}
-	
-	private Predicate<Annotation[]> hasAnnotation(final Class<?> annotation) {
-		return new Predicate<Annotation[]>() {
-			public boolean apply(Annotation[] param) {
-			return any(asList(param), instanceOf(annotation));
-			}
-		};
-	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/pico/PicoComponentRegistry.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/pico/PicoComponentRegistry.java
@@ -260,9 +260,9 @@ public class PicoComponentRegistry extends AbstractComponentRegistry {
 	 * @param componentFactoryMap
 	 */
 	private void registerComponentFactories(MutablePicoContainer container, Map<Class<?>, Class<? extends ComponentFactory>> componentFactoryMap) {
-	for (Class<?> targetType : componentFactoryMap.keySet()) {
-		container.addAdapter(new PicoComponentAdapter(targetType, componentFactoryMap.get(targetType)));
-	}
+		for (Map.Entry<Class<?>, Class<? extends ComponentFactory>> targetTypeEntry : componentFactoryMap.entrySet()) {
+			container.addAdapter(new PicoComponentAdapter(targetTypeEntry.getKey(), targetTypeEntry.getValue()));
+		}
 	}
 
 	public Collection<Class<?>> getAllRegisteredApplicationScopedComponents() {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/restfulie/serialization/LinkConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/restfulie/serialization/LinkConverter.java
@@ -71,13 +71,6 @@ public class LinkConverter implements Converter {
 		}
 	}
 
-	private static Object getRoot(Object root) {
-		if (root instanceof ConfigurableHypermediaResource) {
-			return ((ConfigurableHypermediaResource) root).getModel();
-		}
-		return root;
-	}
-
 	public Object unmarshal(HierarchicalStreamReader arg0,
 			UnmarshallingContext arg1) {
 		return base.unmarshal(arg0, arg1);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:UnusedPrivateMethod - Unused private method should be removed
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:UnusedPrivateMethod
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864

Please let me know if you have any questions.

M-Ezzat